### PR TITLE
Exclude 'output' and 'git' schemes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { EXTENSION_NAME, DecoratorSettings, getSettings } from "./config";
 import { setTabsToReadOnly, setTabToReadOnly, isNonWorkspace } from "./processTabs";
+import { isVSCodeScheme } from "./utilities";
 
 
 
@@ -21,7 +22,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	vscode.window.onDidChangeActiveTextEditor(async event => {
 		const Uri = event?.document?.uri;
-		const notVSCodeScheme = (Uri?.scheme !== 'vscode-userdata')  &&  (Uri?.scheme !== 'vscode-settings');
+		const notVSCodeScheme = Uri !== undefined  &&  !isVSCodeScheme(Uri.scheme);
 		
 		if (Uri  &&  notVSCodeScheme  &&  await isNonWorkspace(Uri)) await setTabToReadOnly(Uri, true);
 	});

--- a/src/processTabs.ts
+++ b/src/processTabs.ts
@@ -13,7 +13,7 @@ export async function setTabsToReadOnly(tabGroups: vscode.TabGroups)  {
 
       if (tab.input instanceof vscode.TabInputText) {
 
-        if (tab.input.uri.scheme !== 'vscode-userdata'  &&  tab.input.uri.scheme !== 'vscode-settings') {
+        if (!utilities.isVSCodeScheme(tab.input.uri.scheme)) {
           if (await isNonWorkspace(tab.input.uri)) await setTabToReadOnly(tab.input.uri, tab.isActive);
         }
       }
@@ -23,8 +23,7 @@ export async function setTabsToReadOnly(tabGroups: vscode.TabGroups)  {
 }
 
 
-export async function setTabToReadOnly(Uri: vscode.Uri, active: boolean)  {
-
+export async function setTabToReadOnly(Uri: vscode.Uri, active: boolean) {
     // if not the active tab, make it active so can use the setActiveEditorReadonlyInSession command
   if (!active) await vscode.commands.executeCommand('vscode.open', Uri);
   await vscode.commands.executeCommand('workbench.action.files.setActiveEditorReadonlyInSession');

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -36,3 +36,7 @@ export async function getfocusGroupCommand(viewColumn: Number): Promise<string> 
 	}
 }
 
+export function isVSCodeScheme(scheme: string): boolean {
+	return (scheme === 'vscode-userdata' || scheme === 'vscode-settings' || scheme === 'output' || scheme === 'git');
+}
+


### PR DESCRIPTION
Currently, this extension can make RO active file from workspace if opened output window or git diff. This PR fixes it.

Also, may be better toggle RO only for 'file' scheme...